### PR TITLE
Improve method typings and mistake in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
 <!-- Link References -->
+
 [repo]: https://github.com/csqrl/BasicState
 [contribs]: https://github.com/csqrl/BasicState/graphs/contributors
 [actions]: https://github.com/csqrl/BasicState/actions
 [latest-release]: https://github.com/csqrl/BasicState/releases/latest
-
 [docs]: https://csqrl.github.io/BasicState
 [docs-example]: https://csqrl.github.io/BasicState/example
-
 [forum]: https://devforum.roblox.com/t/571355
 [forum-dm]: https://devforum.roblox.com/new-message?username=csqrl
 
 <!-- Image References -->
+
 [img-cover]: resources/basicstate-cover.png
 [img-ci-status]: https://github.com/csqrl/BasicState/actions/workflows/ci.yml/badge.svg
 [img-latest-release]: https://img.shields.io/github/v/release/csqrl/BasicState?label=version
@@ -20,40 +20,44 @@
 BasicState is a really, really simple key-value based state management solution. It makes use of [BindableEvents](https://developer.roblox.com/en-us/api-reference/class/BindableEvent) to allow your projects to watch for changes in state, and provides a simple API for communication with your state objects. Think [Rodux](https://roblox.github.io/rodux/), but much more simple.
 
 ## Getting Started
+
 [Visit the documentation site][docs] to get started with BasicState, see examples, and view the full documentation.
 
 ## Contributors
+
 A huge thanks to [the contributors][contribs] of this project. You've added some awesome new features and helps work out a few kinks.
 
 ## Documentation
+
 Documentation is available on the [documentation site][docs].
 
 ## Examples
+
 For examples, please see the [documentation site][docs-example].
 
 **Basic example:**
+
 ```typescript
 import BasicState from "@rbxts/BasicState";
 
 interface IState {
-    Hello: String
+	Hello: String;
 }
 
 let State = new BasicState({
-    Hello: "World"
+	Hello: "World",
 } as IState);
 
 State.GetChangedSignal("Hello").Connect((NewValue, OldValue) => {
-    print(`Hello, {NewValue}; goodbye {OldValue}!`);
+	print(`Hello, ${NewValue}; goodbye ${OldValue}!`);
 });
 
 State.SetState({
-    Hello: "Roblox"
-} as IState)
+	Hello: "Roblox",
+} as IState);
 
 //    Triggers the RBXScriptConnection above and prints
 //    "Hello, Roblox; goodbye World!"
-
 ```
 
 **Usage with Roact (EXAMPLE NOT IN TYPESCRIPT)**
@@ -71,6 +75,7 @@ return Store
 ```
 
 `MyProject.Components.MyComponent.lua`:
+
 ```lua
 local Roact = require(path.to.Roact)
 local MyComponent = Roact.Component:extend("MyComponent")
@@ -97,5 +102,6 @@ return Store:Roact(MyComponent, { "Hello" })
 ```
 
 ## Get in Touch
+
 Please refer to the [thread on the Roblox Developer Forums][forum] if you wish to discuss BasicState.
 You can also contact me via direct message [on the DevForums][forum-dm].

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
-  "name": "@rbxts/BasicState",
-  "version": "1.0.0",
+  "name": "@rbxts/basicstate",
+  "version": "1.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -28,7 +28,7 @@ interface State<T> {
 	 * which will be added to or mutated in the store. This is a deep copy, so
 	 * original data will not be overwritten unless specified.
      */
-    SetState(StateTable: T): void,
+    SetState(StateTable: Partial<T>): void,
 
     /**
      * Allows a stored boolean value to be toggled between true and false. Will throw
@@ -61,13 +61,17 @@ interface State<T> {
 	 * with Roblox's :GetPropertyChangedSignal() method, which returns a single
 	 * RBXScriptConnection
      */
-    GetChangedSignal<K extends keyof T>(Key: K): RBXScriptSignal<(OldValue: T[K], NewValue: T[K]) => void>,
+    GetChangedSignal<K extends keyof T>(Key: K): RBXScriptSignal<(
+        NewValue: T[K],
+        OldValue: T[K],
+        OldState: Readonly<T>) => void
+    >,
 
     /**
      * Wraps a Roact component and injects the given keys into the component's state.
 	 * The component will be re-rendered when State changes.
      */
-    Roact<K extends keyof T>(Component: Roact.Component, Keys?: K[]): Roact.Component,
+    Roact<K extends keyof T, C extends Roact.ComponentConstructor<any>>(Component: C, Keys?: K[]): C,
 
     /**
      * Destroys all BindableEvents created using GetChangedSignal, the .Changed event's
@@ -75,9 +79,12 @@ interface State<T> {
      */
     Destroy(): void,
 
-    Changed: RBXScriptSignal,
+    Changed: RBXScriptSignal<(
+        OldState: Readonly<T>,
+        ChangedKey: keyof T) => void
+    >,
     ProtectType: boolean,
-    None: Instance
+    None: StateConstructor["None"];
 }
 
 interface StateConstructor {
@@ -85,6 +92,8 @@ interface StateConstructor {
      * Create and returns new BasicState instance
      */
     new<T>(InitialState: T): State<T>
+
+    readonly None: symbol;
 }
 
 declare const BasicState: StateConstructor;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,20 +1,25 @@
 import Roact from "@rbxts/roact";
 
-interface State<T> {
+interface State<T = {}> {
     /**
      * Retrieve and return a value from the store. Optionally takes a DefaultValue
 	 * parameter, which will be returned if the stored value is nil
+     * @param Key
+     * @param DefaultValue
      */
     Get<K extends keyof T>(Key: K, DefaultValue?: T[K]): Readonly<T[K]>,
 
     /**
      * Sets a value in the state and triggers Changed events. Will not fire
 	 * events when the passed value is the same as the already stored value
+     * @param Key
+     * @param Value
      */
     Set<K extends keyof T>(Key: K, Value: T[K]): void,
 
     /**
      * Delete a key from the store by setting its value to BasicState.None.
+     * @param Key
      */
     Delete<K extends keyof T>(Key: K): void,
 
@@ -27,12 +32,14 @@ interface State<T> {
      * Like React's setState method, SetState accepts a table of key-value pairs,
 	 * which will be added to or mutated in the store. This is a deep copy, so
 	 * original data will not be overwritten unless specified.
+     * @param StateTable
      */
     SetState(StateTable: Partial<T>): void,
 
     /**
      * Allows a stored boolean value to be toggled between true and false. Will throw
 	 * and error if the stored value is not boolean
+     * @param Key
      */
     Toggle<K extends keyof T>(Key: K): void,
 
@@ -40,6 +47,9 @@ interface State<T> {
      * Increment a stored number by 1. Optionally takes an Amount parameter, which allows
 	 * the user to specify how much to increment by, and a Cap parameter, which will
 	 * prevent the value from exceeding the specified number
+     * @param Key
+     * @param Number
+     * @param Cap
      */
     Increment<K extends keyof T>(Key: K, Number?: number, Cap?: number): void,
 
@@ -47,11 +57,16 @@ interface State<T> {
      * Decrement a stored number by 1. As with the Increment method, optional Amount
 	 * and Cap parameters may be passed to specify how much to decrement the value by.
 	 * Setting a Cap prevents the value from falling below the specified number.
+     * @param Key
+     * @param Number
+     * @param Cap
      */
     Decrement<K extends keyof T>(Key: K, Number?: number, Cap?: number): void,
 
     /**
      * Set a value without triggering Changed events and bypasses ProtectType
+     * @param Key
+     * @param Value
      */
     RawSet<K extends keyof T>(Key: K, Value: T[K]): void,
 
@@ -60,6 +75,7 @@ interface State<T> {
 	 * The returned value is the new BindableEvent's .Event event, to keep consistency
 	 * with Roblox's :GetPropertyChangedSignal() method, which returns a single
 	 * RBXScriptConnection
+     * @param Key
      */
     GetChangedSignal<K extends keyof T>(Key: K): RBXScriptSignal<(
         NewValue: T[K],
@@ -70,8 +86,13 @@ interface State<T> {
     /**
      * Wraps a Roact component and injects the given keys into the component's state.
 	 * The component will be re-rendered when State changes.
+     * @param Component
+     * @param Keys
      */
-    Roact<K extends keyof T, C extends Roact.ComponentConstructor<any>>(Component: C, Keys?: K[]): C,
+    Roact<
+        K extends keyof T,
+        C extends Roact.ComponentConstructor<any>
+    >(Component: C, Keys?: K[]): C,
 
     /**
      * Destroys all BindableEvents created using GetChangedSignal, the .Changed event's
@@ -79,11 +100,29 @@ interface State<T> {
      */
     Destroy(): void,
 
+    /**
+     * An RBXScriptSignal which is fired any time the state mutates.
+     * The Event fires with the following values (in order):
+     */
     Changed: RBXScriptSignal<(
         OldState: Readonly<T>,
         ChangedKey: keyof T) => void
     >,
+
+    /**
+     * A boolean value which determines whether strict type-checking is enabled on
+     * the state table. This prevents changing the type of stored data,
+     * e.g. from a number to a string. This is **disabled** by default.
+     */
     ProtectType: boolean,
+
+    /**
+     * Lua is unable to determine whether a value in a table is ```nil``` or ```undefined```,
+     * and removes nil values from tables as a result. ```State.None``` is designed to
+     * stand in to enable you to remove keys from the state object,
+     * which was previously impossible without. It can be used directly with ```:Set```,
+     * ```:SetState``` or ```:RawSet```, or by using ```:Delete``` to remove a single key.
+     */
     None: StateConstructor["None"];
 }
 
@@ -91,10 +130,24 @@ interface StateConstructor {
     /**
      * Create and returns new BasicState instance
      */
-    new<T>(InitialState: T): State<T>
+    new<T>(InitialState?: T): State<T>
 
+    /**
+     * Lua is unable to determine whether a value in a table is ```nil``` or ```undefined```,
+     * and removes nil values from tables as a result. ```State.None``` is designed to
+     * stand in to enable you to remove keys from the state object,
+     * which was previously impossible without. It can be used directly with ```:Set```,
+     * ```:SetState``` or ```:RawSet```, or by using ```:Delete``` to remove a single key.
+     */
     readonly None: symbol;
 }
 
+/**
+ * BasicState is a really, really simple key-value based state management solution.
+ * It makes use of BindableEvents to allow your projects to watch for changes in state,
+ * and provides a simple API for communication with your state objects.
+ * 
+ * Think Rodux, but much more simple.
+ */
 declare const BasicState: StateConstructor;
 export = BasicState;


### PR DESCRIPTION
I want to improve your repository by fixing typings for Roact, SetState, GetChangedSignal, Changed and None class methods.